### PR TITLE
fix: Invalid Property Resources error

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -134,7 +134,7 @@ Resources:
       InstanceTypes: 
         - !Ref BuildInstanceType
       InstanceProfileName: !Ref EC2ImageBuilderIAMInstanceProfile
-      SNSTopicArn: !Ref ImageBuilderSNSTopic
+      SnsTopicArn: !Ref ImageBuilderSNSTopic
       SubnetId: !Ref PublicSubnet1
       SecurityGroupIds: 
         - !GetAtt VPC.DefaultSecurityGroup


### PR DESCRIPTION
*Issue #, if available:* Closes #4

*Description of changes:*

Change property from `SNSTopicArn` to `SnsTopicArn` as documented in the [AWS CloudFormation documentation: AWS::ImageBuilder::InfrastructureConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html#cfn-imagebuilder-infrastructureconfiguration-snstopicarn)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
